### PR TITLE
Ajouter lumière, physique joueur, mobs, inventaire créatif et biomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # Minecraft Voxel Engine
-Voxel Engine (like Minecraft) in Python and OpenGL 
+Voxel Engine (like Minecraft) in Python and OpenGL.
 
-Control: ZQSDAE + mouse
+## Nouvelles fonctionnalités
+- Cycle jour/nuit + blocs émissifs (`GLOWSTONE`) pour une gestion de lumière simple.
+- Physique joueur: gravité, saut, collisions (désactivable avec noclip).
+- Mobs passifs/hostiles avec déplacement basique et dégâts en contact.
+- Inventaire créatif: choix de blocs (molette + touches `1..9`) et pose/destruction illimitée.
+- Nouveaux blocs: pierre taillée, planches, briques, argile, pierre lumineuse.
+- Biomes (plaines, désert, montagnes, neige, marais) influençant terrain et blocs.
+
+## Contrôles
+- Déplacement: `ZQSD`
+- Saut (physique): `Space`
+- Mode noclip (vol): `F`, puis monter/descendre avec `A/E`
+- Casser/poser un bloc: clic gauche / clic droit
+- Changer de bloc: molette souris ou touches `1..9`
 
 ![minecraft](/screenshot/0.jpg)

--- a/main.py
+++ b/main.py
@@ -46,7 +46,10 @@ class VoxelEngine:
 
         self.delta_time = self.clock.tick()
         self.time = pg.time.get_ticks() * 0.001
-        pg.display.set_caption(f'{self.clock.get_fps() :.0f}')
+        vh = self.scene.world.voxel_handler
+        block_name = BLOCK_NAMES.get(vh.new_voxel_id, str(vh.new_voxel_id))
+        mode = 'POSE' if vh.interaction_mode else 'CASSE'
+        pg.display.set_caption(f"FPS {self.clock.get_fps() :.0f} | {mode} | Bloc: {block_name} | Vie: {self.player.health} | Noclip: {'ON' if self.player.noclip else 'OFF'}")
 
     def render(self):
         self.ctx.clear(color=BG_COLOR)

--- a/player.py
+++ b/player.py
@@ -1,4 +1,5 @@
 import pygame as pg
+import glm
 from camera import Camera
 from settings import *
 
@@ -7,20 +8,41 @@ class Player(Camera):
     def __init__(self, app, position=PLAYER_POS, yaw=-90, pitch=0):
         self.app = app
         super().__init__(position, yaw, pitch)
+        self.velocity_y = 0.0
+        self.on_ground = False
+        self.noclip = False
+        self.health = PLAYER_MAX_HEALTH
 
     def update(self):
         self.keyboard_control()
         self.mouse_control()
+        self.apply_physics()
         super().update()
 
     def handle_event(self, event):
+        voxel_handler = self.app.scene.world.voxel_handler
+
         # adding and removing voxels with clicks
         if event.type == pg.MOUSEBUTTONDOWN:
-            voxel_handler = self.app.scene.world.voxel_handler
             if event.button == 1:
                 voxel_handler.set_voxel()
             if event.button == 3:
                 voxel_handler.switch_mode()
+            if event.button == 4:
+                voxel_handler.cycle_inventory(1)
+            if event.button == 5:
+                voxel_handler.cycle_inventory(-1)
+
+        if event.type == pg.KEYDOWN:
+            if event.key == pg.K_f:
+                self.noclip = not self.noclip
+
+            number_keys = {
+                pg.K_1: 0, pg.K_2: 1, pg.K_3: 2, pg.K_4: 3, pg.K_5: 4,
+                pg.K_6: 5, pg.K_7: 6, pg.K_8: 7, pg.K_9: 8,
+            }
+            if event.key in number_keys:
+                voxel_handler.set_inventory_slot(number_keys[event.key])
 
     def mouse_control(self):
         mouse_dx, mouse_dy = pg.mouse.get_rel()
@@ -32,15 +54,70 @@ class Player(Camera):
     def keyboard_control(self):
         key_state = pg.key.get_pressed()
         vel = PLAYER_SPEED * self.app.delta_time
+
+        flat_forward = glm.normalize(glm.vec3(self.forward.x, 0, self.forward.z))
+        flat_right = glm.normalize(glm.vec3(self.right.x, 0, self.right.z))
+
         if key_state[pg.K_z]:
-            self.move_forward(vel)
+            self.position += flat_forward * vel
         if key_state[pg.K_s]:
-            self.move_back(vel)
+            self.position -= flat_forward * vel
         if key_state[pg.K_d]:
-            self.move_right(vel)
+            self.position += flat_right * vel
         if key_state[pg.K_q]:
-            self.move_left(vel)
-        if key_state[pg.K_a]:
-            self.move_up(vel)
-        if key_state[pg.K_e]:
-            self.move_down(vel)
+            self.position -= flat_right * vel
+
+        if self.noclip:
+            if key_state[pg.K_a]:
+                self.move_up(vel)
+            if key_state[pg.K_e]:
+                self.move_down(vel)
+        elif key_state[pg.K_SPACE] and self.on_ground:
+            self.velocity_y = JUMP_SPEED
+            self.on_ground = False
+
+    def collides(self, position):
+        world = self.app.scene.world
+        px, py, pz = position
+
+        min_x = px - PLAYER_WIDTH
+        max_x = px + PLAYER_WIDTH
+        min_y = py
+        max_y = py + PLAYER_HEIGHT
+        min_z = pz - PLAYER_WIDTH
+        max_z = pz + PLAYER_WIDTH
+
+        for x in (min_x, max_x):
+            for y in (min_y, max_y):
+                for z in (min_z, max_z):
+                    if world.is_solid_at(x, y, z):
+                        return True
+        return False
+
+    def apply_physics(self):
+        if self.noclip:
+            self.velocity_y = 0.0
+            self.on_ground = False
+            return
+
+        old_pos = glm.vec3(self.position)
+
+        # Horizontal collision separation
+        test_x = glm.vec3(self.position.x, old_pos.y, old_pos.z)
+        if self.collides(test_x):
+            self.position.x = old_pos.x
+
+        test_z = glm.vec3(self.position.x, old_pos.y, self.position.z)
+        if self.collides(test_z):
+            self.position.z = old_pos.z
+
+        self.velocity_y = max(self.velocity_y - GRAVITY * self.app.delta_time, -MAX_FALL_SPEED)
+        self.position.y += self.velocity_y
+
+        if self.collides(self.position):
+            if self.velocity_y < 0:
+                self.on_ground = True
+            self.position.y = old_pos.y
+            self.velocity_y = 0.0
+        else:
+            self.on_ground = False

--- a/settings.py
+++ b/settings.py
@@ -46,14 +46,19 @@ PITCH_MAX = glm.radians(89)
 # player
 PLAYER_SPEED = 0.005
 PLAYER_ROT_SPEED = 0.003
-# PLAYER_POS = glm.vec3(CENTER_XZ, WORLD_H * CHUNK_SIZE, CENTER_XZ)
 PLAYER_POS = glm.vec3(CENTER_XZ, CHUNK_SIZE, CENTER_XZ)
 MOUSE_SENSITIVITY = 0.002
+PLAYER_WIDTH = 0.35
+PLAYER_HEIGHT = 1.8
+GRAVITY = 0.0025
+JUMP_SPEED = 0.055
+MAX_FALL_SPEED = 0.09
+PLAYER_MAX_HEALTH = 20
 
 # colors
 BG_COLOR = glm.vec3(0.58, 0.83, 0.99)
 
-# textures
+# textures / blocks
 SAND = 1
 GRASS = 2
 DIRT = 3
@@ -62,6 +67,33 @@ SNOW = 5
 LEAVES = 6
 WOOD = 7
 
+# extra block ids (rendered by reusing texture-array layers)
+COBBLESTONE = 8
+PLANKS = 9
+BRICK = 10
+CLAY = 11
+GLOWSTONE = 12
+
+INVENTORY_BLOCK_IDS = [
+    GRASS, DIRT, STONE, SAND, SNOW, LEAVES, WOOD,
+    COBBLESTONE, PLANKS, BRICK, CLAY, GLOWSTONE,
+]
+
+BLOCK_NAMES = {
+    GRASS: 'Herbe',
+    DIRT: 'Terre',
+    STONE: 'Pierre',
+    SAND: 'Sable',
+    SNOW: 'Neige',
+    LEAVES: 'Feuilles',
+    WOOD: 'Bois',
+    COBBLESTONE: 'Pierre taillée',
+    PLANKS: 'Planches',
+    BRICK: 'Briques',
+    CLAY: 'Argile',
+    GLOWSTONE: 'Pierre lumineuse',
+}
+
 # terrain levels
 SNOW_LVL = 54
 STONE_LVL = 49
@@ -69,10 +101,21 @@ DIRT_LVL = 40
 GRASS_LVL = 8
 SAND_LVL = 7
 
+# biomes
+BIOME_PLAINS = 0
+BIOME_DESERT = 1
+BIOME_MOUNTAINS = 2
+BIOME_SNOW = 3
+BIOME_SWAMP = 4
+
 # tree settings
 TREE_PROBABILITY = 0.02
 TREE_WIDTH, TREE_HEIGHT = 4, 8
 TREE_H_WIDTH, TREE_H_HEIGHT = TREE_WIDTH // 2, TREE_HEIGHT // 2
+
+# day/night and lighting
+DAY_LENGTH_SEC = 180.0
+MIN_DAYLIGHT = 0.2
 
 # water
 WATER_LINE = 5.6
@@ -81,3 +124,12 @@ WATER_AREA = 5 * CHUNK_SIZE * WORLD_W
 # cloud
 CLOUD_SCALE = 25
 CLOUD_HEIGHT = WORLD_H * CHUNK_SIZE * 2
+
+# mobs
+MOB_COUNT_PASSIVE = 8
+MOB_COUNT_HOSTILE = 6
+MOB_SPEED_PASSIVE = 0.01
+MOB_SPEED_HOSTILE = 0.013
+MOB_DAMAGE = 2
+MOB_ATTACK_COOLDOWN = 1.2
+MOB_DESPAWN_DIST = CHUNK_SIZE * 2

--- a/shader_program.py
+++ b/shader_program.py
@@ -21,6 +21,7 @@ class ShaderProgram:
         self.chunk['u_texture_array_0'] = 1
         self.chunk['bg_color'].write(BG_COLOR)
         self.chunk['water_line'] = WATER_LINE
+        self.chunk['day_light'] = 1.0
 
         # marker
         self.voxel_marker['m_proj'].write(self.player.m_proj)
@@ -41,6 +42,8 @@ class ShaderProgram:
 
     def update(self):
         self.chunk['m_view'].write(self.player.m_view)
+        if hasattr(self.app, 'scene') and hasattr(self.app.scene, 'world'):
+            self.chunk['day_light'] = self.app.scene.world.daylight
         self.voxel_marker['m_view'].write(self.player.m_view)
         self.water['m_view'].write(self.player.m_view)
         self.clouds['m_view'].write(self.player.m_view)

--- a/shaders/chunk.frag
+++ b/shaders/chunk.frag
@@ -8,6 +8,7 @@ const vec3 inv_gamma = 1 / gamma;
 uniform sampler2DArray u_texture_array_0;
 uniform vec3 bg_color;
 uniform float water_line;
+uniform float day_light;
 
 in vec2 uv;
 in float shading;
@@ -21,10 +22,15 @@ void main() {
     vec2 face_uv = uv;
     face_uv.x = uv.x / 3.0 - min(face_id, 2) / 3.0;
 
-    vec3 tex_col = texture(u_texture_array_0, vec3(face_uv, voxel_id)).rgb;
+    int layer_count = max(textureSize(u_texture_array_0, 0).z, 1);
+    int layer = voxel_id % layer_count;
+
+    vec3 tex_col = texture(u_texture_array_0, vec3(face_uv, layer)).rgb;
     tex_col = pow(tex_col, gamma);
 
-    tex_col *= shading;
+    float emissive = voxel_id == 12 ? 0.75 : 0.0;
+    float light_level = max(day_light, emissive);
+    tex_col *= shading * light_level;
 
     // underwater effect
     if (frag_world_pos.y < water_line) tex_col *= vec3(0.0, 0.3, 1.0);

--- a/terrain_gen.py
+++ b/terrain_gen.py
@@ -4,7 +4,23 @@ from settings import *
 
 
 @njit
+def get_biome(x, z):
+    biome_noise = noise2(x * 0.0015 + 61.7, z * 0.0015 - 28.3)
+    if biome_noise < -0.45:
+        return BIOME_DESERT
+    if biome_noise < -0.1:
+        return BIOME_PLAINS
+    if biome_noise < 0.2:
+        return BIOME_SWAMP
+    if biome_noise < 0.55:
+        return BIOME_MOUNTAINS
+    return BIOME_SNOW
+
+
+@njit
 def get_height(x, z):
+    biome = get_biome(x, z)
+
     # island mask
     island = 1 / (pow(0.0025 * math.hypot(x - CENTER_XZ, z - CENTER_XZ), 20) + 0.0001)
     island = min(island, 1)
@@ -12,6 +28,15 @@ def get_height(x, z):
     # amplitude
     a1 = CENTER_Y
     a2, a4, a8 = a1 * 0.5, a1 * 0.25, a1 * 0.125
+
+    if biome == BIOME_DESERT:
+        a1 *= 0.65
+    elif biome == BIOME_MOUNTAINS:
+        a1 *= 1.55
+    elif biome == BIOME_SWAMP:
+        a1 *= 0.8
+    elif biome == BIOME_SNOW:
+        a1 *= 1.2
 
     # frequency
     f1 = 0.005
@@ -26,7 +51,7 @@ def get_height(x, z):
     height += noise2(x * f4, z * f4) * a4 + a4
     height += noise2(x * f8, z * f8) * a8 - a8
 
-    height = max(height,  noise2(x * f8, z * f8) + 2)
+    height = max(height, noise2(x * f8, z * f8) + 2)
     height *= island
 
     return int(height)
@@ -38,7 +63,7 @@ def get_index(x, y, z):
 
 
 @njit
-def set_voxel_id(voxels, x, y, z, wx, wy, wz, world_height):
+def set_voxel_id(voxels, x, y, z, wx, wy, wz, world_height, biome):
     voxel_id = 0
 
     if wy < world_height - 1:
@@ -48,30 +73,45 @@ def set_voxel_id(voxels, x, y, z, wx, wy, wz, world_height):
             voxel_id = 0
 
         else:
-            voxel_id = STONE
+            voxel_id = STONE if biome != BIOME_DESERT else SAND
     else:
         rng = int(7 * random())
         ry = wy - rng
-        if SNOW_LVL <= ry < world_height:
-            voxel_id = SNOW
 
-        elif STONE_LVL <= ry < SNOW_LVL:
-            voxel_id = STONE
-
-        elif DIRT_LVL <= ry < STONE_LVL:
-            voxel_id = DIRT
-
-        elif GRASS_LVL <= ry < DIRT_LVL:
-            voxel_id = GRASS
-
+        if biome == BIOME_DESERT:
+            voxel_id = SAND if random() > 0.08 else CLAY
+        elif biome == BIOME_SNOW:
+            voxel_id = SNOW if ry >= GRASS_LVL else DIRT
+        elif biome == BIOME_SWAMP:
+            voxel_id = DIRT if random() > 0.25 else LEAVES
+        elif biome == BIOME_MOUNTAINS:
+            if ry > STONE_LVL + 8:
+                voxel_id = SNOW
+            elif ry > GRASS_LVL:
+                voxel_id = STONE if random() > 0.12 else COBBLESTONE
+            else:
+                voxel_id = DIRT
         else:
-            voxel_id = SAND
+            if SNOW_LVL <= ry < world_height:
+                voxel_id = SNOW
+            elif STONE_LVL <= ry < SNOW_LVL:
+                voxel_id = STONE
+            elif DIRT_LVL <= ry < STONE_LVL:
+                voxel_id = DIRT
+            elif GRASS_LVL <= ry < DIRT_LVL:
+                voxel_id = GRASS
+            else:
+                voxel_id = SAND
+
+    # rare glowing stone veins underground
+    if voxel_id == STONE and wy < GRASS_LVL and random() < 0.004:
+        voxel_id = GLOWSTONE
 
     # setting ID
     voxels[get_index(x, y, z)] = voxel_id
 
-    # place tree
-    if wy < DIRT_LVL:
+    # place tree only in compatible biomes
+    if (biome == BIOME_PLAINS or biome == BIOME_SWAMP) and wy < DIRT_LVL:
         place_tree(voxels, x, y, z, voxel_id)
 
 

--- a/voxel_handler.py
+++ b/voxel_handler.py
@@ -16,7 +16,8 @@ class VoxelHandler:
         self.voxel_normal = None
 
         self.interaction_mode = 0  # 0: remove voxel   1: add voxel
-        self.new_voxel_id = DIRT
+        self.inventory_index = 0
+        self.new_voxel_id = INVENTORY_BLOCK_IDS[self.inventory_index]
 
     def add_voxel(self):
         if self.voxel_id:
@@ -72,6 +73,16 @@ class VoxelHandler:
 
     def switch_mode(self):
         self.interaction_mode = not self.interaction_mode
+
+
+    def cycle_inventory(self, step):
+        self.inventory_index = (self.inventory_index + step) % len(INVENTORY_BLOCK_IDS)
+        self.new_voxel_id = INVENTORY_BLOCK_IDS[self.inventory_index]
+
+    def set_inventory_slot(self, slot):
+        if 0 <= slot < len(INVENTORY_BLOCK_IDS):
+            self.inventory_index = slot
+            self.new_voxel_id = INVENTORY_BLOCK_IDS[self.inventory_index]
 
     def update(self):
         self.ray_cast()

--- a/world.py
+++ b/world.py
@@ -1,6 +1,7 @@
 from settings import *
 from world_objects.chunk import Chunk
 from voxel_handler import VoxelHandler
+from world_objects.mobs import MobManager
 
 
 class World:
@@ -11,9 +12,13 @@ class World:
         self.build_chunks()
         self.build_chunk_mesh()
         self.voxel_handler = VoxelHandler(self)
+        self.mob_manager = MobManager(self)
+        self.daylight = 1.0
 
     def update(self):
         self.voxel_handler.update()
+        self.mob_manager.update()
+        self.daylight = MIN_DAYLIGHT + (1.0 - MIN_DAYLIGHT) * (0.5 + 0.5 * glm.sin(2.0 * glm.pi() * self.app.time / DAY_LENGTH_SEC))
 
     def build_chunks(self):
         for x in range(WORLD_W):
@@ -37,3 +42,18 @@ class World:
     def render(self):
         for chunk in self.chunks:
             chunk.render()
+        self.mob_manager.render()
+
+    def get_voxel_id_at(self, x, y, z):
+        wx, wy, wz = int(x), int(y), int(z)
+        cx, cy, cz = wx // CHUNK_SIZE, wy // CHUNK_SIZE, wz // CHUNK_SIZE
+        if not (0 <= cx < WORLD_W and 0 <= cy < WORLD_H and 0 <= cz < WORLD_D):
+            return 0
+
+        chunk_index = cx + WORLD_W * cz + WORLD_AREA * cy
+        lx, ly, lz = wx % CHUNK_SIZE, wy % CHUNK_SIZE, wz % CHUNK_SIZE
+        voxel_index = lx + CHUNK_SIZE * lz + CHUNK_AREA * ly
+        return int(self.voxels[chunk_index][voxel_index])
+
+    def is_solid_at(self, x, y, z):
+        return self.get_voxel_id_at(x, y, z) != 0

--- a/world_objects/chunk.py
+++ b/world_objects/chunk.py
@@ -50,8 +50,9 @@ class Chunk:
             for z in range(CHUNK_SIZE):
                 wz = z + cz
                 world_height = get_height(wx, wz)
+                biome = get_biome(wx, wz)
                 local_height = min(world_height - cy, CHUNK_SIZE)
 
                 for y in range(local_height):
                     wy = y + cy
-                    set_voxel_id(voxels, x, y, z, wx, wy, wz, world_height)
+                    set_voxel_id(voxels, x, y, z, wx, wy, wz, world_height, biome)

--- a/world_objects/mobs.py
+++ b/world_objects/mobs.py
@@ -1,0 +1,117 @@
+import random
+import glm
+from settings import *
+from meshes.cube_mesh import CubeMesh
+
+
+class Mob:
+    def __init__(self, world, hostile=False, position=None):
+        self.world = world
+        self.app = world.app
+        self.hostile = hostile
+        self.position = glm.vec3(position) if position is not None else self._spawn_position()
+        self.velocity_y = 0.0
+        self.direction = glm.normalize(glm.vec3(random.uniform(-1, 1), 0, random.uniform(-1, 1)))
+        self.target_timer = random.uniform(1.0, 4.0)
+        self.attack_timer = 0.0
+
+    def _spawn_position(self):
+        base = self.app.player.position
+        radius = random.uniform(10.0, 28.0)
+        angle = random.uniform(0.0, 6.28)
+        x = base.x + glm.cos(angle) * radius
+        z = base.z + glm.sin(angle) * radius
+        for y in range(CHUNK_SIZE * WORLD_H - 2, 2, -1):
+            if self.world.is_solid_at(x, y, z):
+                return glm.vec3(x, y + 1.05, z)
+        return glm.vec3(base.x + 6.0, WATER_LINE + 2, base.z + 6.0)
+
+    def _update_direction(self, dt):
+        self.target_timer -= dt
+        if self.target_timer <= 0:
+            self.target_timer = random.uniform(1.0, 4.0)
+            self.direction = glm.normalize(glm.vec3(random.uniform(-1, 1), 0, random.uniform(-1, 1)))
+
+        if self.hostile:
+            to_player = self.app.player.position - self.position
+            dist = glm.length(to_player)
+            if dist < 18.0 and dist > 0.001:
+                self.direction = glm.normalize(glm.vec3(to_player.x, 0, to_player.z))
+
+    def _move_horizontal(self, dt):
+        speed = MOB_SPEED_HOSTILE if self.hostile else MOB_SPEED_PASSIVE
+        move = self.direction * speed * self.app.delta_time
+        candidate = self.position + move
+        if not self.world.is_solid_at(candidate.x, self.position.y, candidate.z):
+            self.position = candidate
+
+    def _apply_gravity(self):
+        self.velocity_y = max(self.velocity_y - GRAVITY * self.app.delta_time, -MAX_FALL_SPEED)
+        candidate_y = self.position.y + self.velocity_y
+
+        if self.velocity_y < 0 and self.world.is_solid_at(self.position.x, candidate_y - 1.0, self.position.z):
+            self.position.y = int(candidate_y)
+            self.velocity_y = 0.0
+        else:
+            self.position.y = candidate_y
+
+    def _attack_player(self, dt):
+        if not self.hostile:
+            return
+        self.attack_timer -= dt
+        if self.attack_timer > 0:
+            return
+
+        dist = glm.length(self.app.player.position - self.position)
+        if dist < 1.5:
+            self.attack_timer = MOB_ATTACK_COOLDOWN
+            self.app.player.health = max(0, self.app.player.health - MOB_DAMAGE)
+
+    def update(self, dt):
+        self._update_direction(dt)
+        self._move_horizontal(dt)
+        self._apply_gravity()
+        self._attack_player(dt)
+
+
+class MobManager:
+    def __init__(self, world):
+        self.world = world
+        self.app = world.app
+        self.mesh = CubeMesh(self.app)
+        self.mobs = []
+        self._spawn_initial_mobs()
+
+    def _spawn_initial_mobs(self):
+        for _ in range(MOB_COUNT_PASSIVE):
+            self.mobs.append(Mob(self.world, hostile=False))
+        for _ in range(MOB_COUNT_HOSTILE):
+            self.mobs.append(Mob(self.world, hostile=True))
+
+    def _despawn_and_respawn(self):
+        player_pos = self.app.player.position
+        kept = []
+        for mob in self.mobs:
+            if glm.length(mob.position - player_pos) < MOB_DESPAWN_DIST:
+                kept.append(mob)
+        self.mobs = kept
+
+        while len([m for m in self.mobs if not m.hostile]) < MOB_COUNT_PASSIVE:
+            self.mobs.append(Mob(self.world, hostile=False))
+        while len([m for m in self.mobs if m.hostile]) < MOB_COUNT_HOSTILE:
+            self.mobs.append(Mob(self.world, hostile=True))
+
+    def update(self):
+        dt = max(0.001, self.app.delta_time * 0.001)
+        for mob in self.mobs:
+            mob.update(dt)
+        self._despawn_and_respawn()
+
+    def render(self):
+        program = self.mesh.program
+        for mob in self.mobs:
+            program['mode_id'] = 1 if mob.hostile else 0
+            m_model = glm.translate(glm.mat4(), mob.position)
+            m_model = glm.scale(m_model, glm.vec3(0.8, 1.2, 0.8))
+            program['m_model'].write(m_model)
+            self.mesh.render()


### PR DESCRIPTION
### Motivation
- Étendre le moteur voxel avec des éléments de gameplay demandés : gestion de la lumière, physique du joueur, mobs, inventaire créatif et biomes.
- Fournir une base simple mais extensible (jour/nuit, blocs émissifs, nouveaux IDs de blocs) pour tester rendu et génération de monde.
- Permettre la pose/suppression de blocs en mode créatif et ajouter des entités mobiles pour enrichir l'expérience de jeu.

### Description
- Ajout de constantes et paramètres globaux dans `settings.py` (physique joueur, jour/nuit, nouveaux IDs de blocs, inventaire, paramètres mobs et biomes). 
- Implémentation de la physique joueur dans `player.py` (gravité, saut, collisions, `noclip` toggle avec `F`) et affichage de l’état dans la `caption` via `main.py`.
- Extension de la gestion de voxels dans `voxel_handler.py` pour un inventaire créatif (molette + méthodes `cycle_inventory` / `set_inventory_slot`) et sélection de blocs via touches `1..9`.
- Ajout d’un système de mobs dans `world_objects/mobs.py` (spawn, déplacement basique, gravité, attaques hostiles) et intégration dans `world.py` via `MobManager`.
- Enrichissement de la génération de terrain dans `terrain_gen.py` avec `get_biome` et règles par biome, plus adaptation de `world_objects/chunk.py` pour fournir le biome au générateur.
- Gestion simple de la lumière : calcul d’un facteur `day_light` dans `World`, passage au shader et support d’un bloc émissif (`GLOWSTONE`) dans `shaders/chunk.frag` ainsi que propagation du uniform dans `shader_program.py`.
- Mise à jour de la documentation `README.md` pour résumer les nouvelles fonctionnalités et contrôles.

### Testing
- La compilation statique des fichiers Python a été lancée avec `python -m py_compile $(rg --files -g '*.py')` et a réussi.
- Une tentative antérieure de la même vérification a échoué à cause d’un motif de commande incorrect (`rg --files '*.py'`), non lié aux modifications de code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba7604352483258ece7607fac6f014)