### PR TITLE
Add first-launch dependency installer (bootstrap) and requirements alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Minecraft Voxel Engine
 Voxel Engine (like Minecraft) in Python and OpenGL.
 
+## Installation automatique des dépendances
+- Au premier lancement, le jeu vérifie les dépendances Python et lance automatiquement `pip install -r requirements.txt` si nécessaire.
+- Un fichier marqueur `.first_launch_deps_ok` est créé pour éviter de relancer cette installation à chaque démarrage.
+
 ## Nouvelles fonctionnalités
 - Cycle jour/nuit + blocs émissifs (`GLOWSTONE`) pour une gestion de lumière simple.
 - Physique joueur: gravité, saut, collisions (désactivable avec noclip).

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+MARKER_FILE = ".first_launch_deps_ok"
+REQUIREMENTS_CANDIDATES = ("requirements.txt", "requirment.txt")
+
+
+def _find_requirements_file(base_dir: Path) -> Path | None:
+    for filename in REQUIREMENTS_CANDIDATES:
+        req_path = base_dir / filename
+        if req_path.exists():
+            return req_path
+    return None
+
+
+def ensure_dependencies() -> None:
+    """Install project dependencies once on the very first launch."""
+    base_dir = Path(__file__).resolve().parent
+    marker_path = base_dir / MARKER_FILE
+
+    if marker_path.exists():
+        return
+
+    requirements_path = _find_requirements_file(base_dir)
+    if requirements_path is None:
+        return
+
+    print("[setup] Vérification des dépendances du projet...")
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "-r", str(requirements_path)]
+    )
+    marker_path.write_text("ok\n", encoding="utf-8")
+    print("[setup] Dépendances installées et validées.")

--- a/main.py
+++ b/main.py
@@ -1,3 +1,7 @@
+from bootstrap import ensure_dependencies
+
+ensure_dependencies()
+
 from settings import *
 import moderngl as mgl
 import pygame as pg

--- a/requirment.txt
+++ b/requirment.txt
@@ -1,0 +1,7 @@
+pygame==2.5.0
+moderngl==5.8.2
+numba==0.57.1
+PyGLM==2.7.0
+numpy<1.25,>=1.21
+opensimplex[numpy]==0.4.4
+


### PR DESCRIPTION
### Motivation
- Assurer que les dépendances Python du projet sont présentes au premier lancement et automatiser leur installation si nécessaire.
- Prévenir les réinstallations à chaque démarrage en conservant un marqueur après une installation réussie.
- Fournir une variante de nom de fichier `requirements` demandée (`requirment.txt`) pour compatibilité avec des usages externes.

### Description
- Ajout du module `bootstrap.py` contenant `ensure_dependencies()` qui cherche `requirements.txt` ou `requirment.txt`, exécute `pip install -r ...` et crée le marqueur `.first_launch_deps_ok` après succès.
- Appel de `ensure_dependencies()` au tout début de `main.py` avant les imports de `moderngl`/`pygame` pour garantir que les paquets sont installés avant d'initialiser l'environnement graphique.
- Ajout de `requirment.txt` en tant que copie de `requirements.txt` pour l'alias demandé.
- Mise à jour du `README.md` pour documenter le comportement d'installation automatique au premier lancement.

### Testing
- Compilation vérifiée via `python -m compileall main.py bootstrap.py`, qui s'est exécutée avec succès.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba7ca596c08325914211a396a08c32)