### PR TITLE
Vérification de la version Python et gestion d'erreur lors de l'installation des dépendances

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Voxel Engine (like Minecraft) in Python and OpenGL.
 ## Installation automatique des dépendances
 - Au premier lancement, le jeu vérifie les dépendances Python et lance automatiquement `pip install -r requirements.txt` si nécessaire.
 - Un fichier marqueur `.first_launch_deps_ok` est créé pour éviter de relancer cette installation à chaque démarrage.
+- Versions Python supportées: `3.10` et `3.11` (les dépendances actuelles ne sont pas compatibles avec Python `3.12+`).
 
 ## Nouvelles fonctionnalités
 - Cycle jour/nuit + blocs émissifs (`GLOWSTONE`) pour une gestion de lumière simple.

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -7,6 +7,16 @@ from pathlib import Path
 
 MARKER_FILE = ".first_launch_deps_ok"
 REQUIREMENTS_CANDIDATES = ("requirements.txt", "requirment.txt")
+MIN_PYTHON = (3, 10)
+MAX_PYTHON_EXCLUSIVE = (3, 12)
+
+
+def _is_supported_python() -> bool:
+    return MIN_PYTHON <= sys.version_info[:2] < MAX_PYTHON_EXCLUSIVE
+
+
+def _format_version(version: tuple[int, int]) -> str:
+    return f"{version[0]}.{version[1]}"
 
 
 def _find_requirements_file(base_dir: Path) -> Path | None:
@@ -19,6 +29,16 @@ def _find_requirements_file(base_dir: Path) -> Path | None:
 
 def ensure_dependencies() -> None:
     """Install project dependencies once on the very first launch."""
+    if not _is_supported_python():
+        current = _format_version(sys.version_info[:2])
+        min_supported = _format_version(MIN_PYTHON)
+        max_supported = _format_version((MAX_PYTHON_EXCLUSIVE[0], MAX_PYTHON_EXCLUSIVE[1] - 1))
+        raise RuntimeError(
+            "Version de Python non supportée pour ce projet. "
+            f"Version détectée: {current}. "
+            f"Utilisez Python entre {min_supported} et {max_supported} (inclus), puis relancez le jeu."
+        )
+
     base_dir = Path(__file__).resolve().parent
     marker_path = base_dir / MARKER_FILE
 
@@ -30,8 +50,16 @@ def ensure_dependencies() -> None:
         return
 
     print("[setup] Vérification des dépendances du projet...")
-    subprocess.check_call(
-        [sys.executable, "-m", "pip", "install", "-r", str(requirements_path)]
-    )
+    try:
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "-r", str(requirements_path)]
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            "Échec de l'installation des dépendances. "
+            "Sur Windows, utilisez un environnement Python 3.10 ou 3.11 puis exécutez: "
+            f'"{sys.executable} -m pip install -r {requirements_path}".'
+        ) from exc
+
     marker_path.write_text("ok\n", encoding="utf-8")
     print("[setup] Dépendances installées et validées.")

--- a/main.py
+++ b/main.py
@@ -1,6 +1,10 @@
 from bootstrap import ensure_dependencies
 
-ensure_dependencies()
+try:
+    ensure_dependencies()
+except RuntimeError as exc:
+    print(f"[setup] {exc}")
+    raise SystemExit(1) from exc
 
 from settings import *
 import moderngl as mgl


### PR DESCRIPTION
### Motivation
- Les installations de dépendances peuvent échouer silencieusement avec des erreurs de compilation (notamment `pygame` sur Python 3.12+), rendant le diagnostic difficile pour l'utilisateur. 
- Le démarrage doit échouer de façon claire et actionnable quand l'interpréteur n'est pas supporté afin d'éviter de longues traces d'erreur de `pip`.

### Description
- Ajout d'une garde de version dans `bootstrap.py` avec `MIN_PYTHON`/`MAX_PYTHON_EXCLUSIVE` et la fonction `_is_supported_python()` qui lève un `RuntimeError` si la version de Python n'est pas supportée. 
- Ajout de `_format_version()` et d'un message d'erreur lisible expliquant la plage de versions supportées (actuellement `3.10`–`3.11`).
- Encapsulation de l'appel à `pip install -r requirements.txt` dans un `try/except` pour convertir les erreurs `CalledProcessError` en `RuntimeError` avec une instruction actionnable contenant la commande `"{sys.executable} -m pip install -r {requirements_path}"`.
- Wrap de l'appel à `ensure_dependencies()` dans `main.py` pour afficher proprement l'erreur de setup et quitter avec `SystemExit(1)` si nécessaire, et mise à jour de `README.md` pour documenter les versions Python supportées.

### Testing
- Compilation syntaxique vérifiée avec `python -m py_compile bootstrap.py main.py`, et le test a réussi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba80d312bc8325aa16637b6f15b627)