### PR TITLE
Use package-relative paths for assets and shaders to avoid FileNotFoundError

### DIFF
--- a/shader_program.py
+++ b/shader_program.py
@@ -1,4 +1,5 @@
 from settings import *
+from pathlib import Path
 
 
 class ShaderProgram:
@@ -6,6 +7,7 @@ class ShaderProgram:
         self.app = app
         self.ctx = app.ctx
         self.player = app.player
+        self.shaders_dir = Path(__file__).resolve().parent / 'shaders'
         # -------- shaders -------- #
         self.chunk = self.get_program(shader_name='chunk')
         self.voxel_marker = self.get_program(shader_name='voxel_marker')
@@ -49,10 +51,10 @@ class ShaderProgram:
         self.clouds['m_view'].write(self.player.m_view)
 
     def get_program(self, shader_name):
-        with open(f'shaders/{shader_name}.vert') as file:
+        with open(self.shaders_dir / f'{shader_name}.vert') as file:
             vertex_shader = file.read()
 
-        with open(f'shaders/{shader_name}.frag') as file:
+        with open(self.shaders_dir / f'{shader_name}.frag') as file:
             fragment_shader = file.read()
 
         program = self.ctx.program(vertex_shader=vertex_shader, fragment_shader=fragment_shader)

--- a/textures.py
+++ b/textures.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pygame as pg
 import moderngl as mgl
 
@@ -6,6 +8,7 @@ class Textures:
     def __init__(self, app):
         self.app = app
         self.ctx = app.ctx
+        self.assets_dir = Path(__file__).resolve().parent / 'assets'
 
         # load textures
         self.texture_0 = self.load('frame.png')
@@ -18,7 +21,8 @@ class Textures:
         self.texture_1.use(location=2)
 
     def load(self, file_name, is_tex_array=False):
-        texture = pg.image.load(f'assets/{file_name}')
+        texture_path = self.assets_dir / file_name
+        texture = pg.image.load(str(texture_path))
         texture = pg.transform.flip(texture, flip_x=True, flip_y=False)
 
         if is_tex_array:


### PR DESCRIPTION
### Motivation
- The game failed at startup with `FileNotFoundError` when launched from a working directory different from the repository root because asset and shader loads used relative paths based on the process CWD.
- Make texture and shader loading deterministic by resolving paths relative to their source modules so the app can be launched from any folder.

### Description
- In `textures.py` add `assets_dir = Path(__file__).resolve().parent / 'assets'` and load textures with `pg.image.load(str(texture_path))` instead of using `f'assets/{file_name}'` so textures are resolved relative to the module file.
- In `shader_program.py` add `shaders_dir = Path(__file__).resolve().parent / 'shaders'` and open shader files from `self.shaders_dir / f'{shader_name}.vert'` / `self.shaders_dir / f'{shader_name}.frag'` instead of `shaders/...` so shader sources are found regardless of CWD.
- These changes keep behavior identical when running from the project root while fixing launches from arbitrary working directories.

### Testing
- Ran `python -m py_compile main.py textures.py shader_program.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba82f6bdec83259a4953bb34f81a5f)