### PR TITLE
Guard against empty vertex data and release VAO on rebuild

### DIFF
--- a/meshes/base_mesh.py
+++ b/meshes/base_mesh.py
@@ -18,6 +18,15 @@ class BaseMesh:
 
     def get_vao(self):
         vertex_data = self.get_vertex_data()
+        if vertex_data is None:
+            return None
+
+        if isinstance(vertex_data, np.ndarray):
+            if vertex_data.size == 0 or vertex_data.nbytes == 0:
+                return None
+        elif hasattr(vertex_data, "__len__") and len(vertex_data) == 0:
+            return None
+
         vbo = self.ctx.buffer(vertex_data)
         vao = self.ctx.vertex_array(
             self.program, [(vbo, self.vbo_format, *self.attrs)], skip_errors=True
@@ -25,4 +34,5 @@ class BaseMesh:
         return vao
 
     def render(self):
-        self.vao.render()
+        if self.vao is not None:
+            self.vao.render()

--- a/meshes/chunk_mesh.py
+++ b/meshes/chunk_mesh.py
@@ -16,6 +16,8 @@ class ChunkMesh(BaseMesh):
         self.vao = self.get_vao()
 
     def rebuild(self):
+        if self.vao is not None:
+            self.vao.release()
         self.vao = self.get_vao()
 
     def get_vertex_data(self):


### PR DESCRIPTION
### Motivation

- Prevent runtime errors when mesh builders return `None` or empty vertex data that would otherwise be passed to the GL buffer/VAO creation. 
- Avoid leaking GPU resources by releasing an existing VAO before creating a new one during mesh rebuilds.

### Description

- Add defensive checks in `BaseMesh.get_vao` to return `None` when `get_vertex_data()` yields `None`, an empty `numpy.ndarray`, or a zero-length sequence, so no VBO/VAO is created for empty data. 
- Make `BaseMesh.render` robust by only calling `self.vao.render()` when `self.vao` is not `None`. 
- Update `ChunkMesh.rebuild` to call `self.vao.release()` if a VAO already exists before replacing it with a newly created VAO.

### Testing

- Ran the project's automated test suite against the modified code and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba852c35288325805c48de69165ded)